### PR TITLE
Fix stale move lists

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -125,6 +125,8 @@ class Board:
         '''
             Calculate all the possible (valid) moves of an specific piece on a specific position
         '''
+        # always start with a clean move list to avoid outdated entries
+        piece.clear_moves()
 
         def pawn_moves():
             # steps


### PR DESCRIPTION
## Summary
- clear move list when calculating legal moves

## Testing
- `python -m compileall -q src`